### PR TITLE
Add user-agent to wiki call

### DIFF
--- a/src/main/java/com/discordnotificationsaio/ApiTools.java
+++ b/src/main/java/com/discordnotificationsaio/ApiTools.java
@@ -31,7 +31,10 @@ public static String getWikiIcon ( String itemName ) throws IOException, Interru
 			"https://oldschool.runescape.wiki/api.php?action=query&format=json&formatversion=2&prop=pageimages&titles=" +
 			itemName.replace( " ", "_" ).replace( "%20", "_" );
 	OkHttpClient client = new OkHttpClient();
-	Request request = new Request.Builder().url( sURL ).build();
+	Request request = new Request.Builder()
+			.url( sURL )
+			.header("User-Agent", "skyhawkgaming/better-discord-loot-logger")
+			.build();
 	CompletableFuture<String> icon = new CompletableFuture<>();
 	CompletableFuture.supplyAsync( () ->
 		{


### PR DESCRIPTION
OSRS wiki may soon block requests with default okhttp user-agents. This change sets a user-agent on the wiki API calls.